### PR TITLE
Update get_node.rs

### DIFF
--- a/examples/get_node.rs
+++ b/examples/get_node.rs
@@ -1,59 +1,73 @@
-//this method get nodes from PackedScene using rust
-
-//let scene = load::<PackedScene>("res://Player/players.tscn");
-        
-//let instance = scene.instantiate().unwrap();
-//self.base_mut().add_child(&instance);
-
-use godot::classes::{ ITileMapLayer, Label, TileMapLayer};
+use godot::classes::{ITileMapLayer, Label, Node, PackedScene, TileMapLayer};
 use godot::obj::NewGd;
 use godot::prelude::*;
 
-
+/// A custom TileMapLayer that instantiates a `PackedScene` and modifies a `Label`.
 #[derive(GodotClass)]
 #[class(base=TileMapLayer)]
-pub struct Tilesm{
+pub struct Tilesm {
+    /// The underlying TileMapLayer.
     #[base]
     base: Base<TileMapLayer>,
 
+    /// A `PackedScene` that we'll instantiate in code.
     #[export]
-    plays: Gd<PackedScene>
-    
+    plays: Gd<PackedScene>,
 }
 
-
 #[godot_api]
-impl ITileMapLayer for Tilesm{
-
+impl ITileMapLayer for Tilesm {
+    /// Called when Godot instantiates this script.
     fn init(base: Base<TileMapLayer>) -> Self {
         Self {
-            
-            base, 
-            plays: PackedScene::new_gd(),
-
+            base,
+            plays: PackedScene::new_gd(), // Default-empty Gd<PackedScene> for safety.
         }
     }
 
-    fn ready(&mut self){
-        self.op();
-        
+    /// Runs once this `TileMapLayer` is ready in the scene tree.
+    fn ready(&mut self) {
+        self.instantiate_and_configure_scene();
     }
-
 }
 
 #[godot_api]
 impl Tilesm {
+    /// Attempts to instantiate the `plays` scene, add it as a child, and configure a Label node.
     #[func]
-    fn op(&mut self) {
-        let p: Gd<Node> = self.get_plays().instantiate().unwrap();
-        
-        
-        self.base_mut().add_child(&p);
-        let mut label = p.get_node_as::<Label>("/root/Tilesm/PLAYERS/Label");
-        
-        label.set_text("hello from ptit");
+    fn instantiate_and_configure_scene(&mut self) {
+        // Safely attempt to instantiate the 'plays' scene
+        let Some(plays_scene) = self.plays.to_option() else {
+            godot_error!("Tilesm: 'plays' scene is not assigned. Aborting instantiation.");
+            return;
+        };
 
-      
+        let instance_result = plays_scene.instantiate();
+        let Some(instance) = instance_result else {
+            godot_error!("Tilesm: Failed to instantiate 'plays' PackedScene.");
+            return;
+        };
+
+        // Add the newly created instance to 'self' (this TileMapLayer)
+        self.base_mut().add_child(&instance);
+
+        // Attempt to fetch the Label using a relative path or an absolute path:
+        //   - If it's relative to the instance: "PLAYERS/Label"
+        //   - If it's an absolute path in the scene tree: "/root/Tilesm/PLAYERS/Label"
+        //   (Adjust based on how your scene is structured)
+        let label_path = "PLAYERS/Label"; // or "/root/Tilesm/PLAYERS/Label"
+        let label_node = instance
+            .get_node_as::<Label>(label_path)
+            .or_else(|| {
+                godot_warn!("Tilesm: Could not find Label at path: {label_path}");
+                None
+            });
+
+        // If found, set the text; if not, skip gracefully
+        if let Some(label) = label_node {
+            label.set_text("Hello from ptit (Rust)!");
+        } else {
+            godot_warn!("Tilesm: No Label found to update text.");
+        }
     }
-    
 }


### PR DESCRIPTION
Below is an improved and more defensive version of the provided Rust/Godot code. The changes focus on robustness, naming clarity, error handling, and best practices for a Godot 4.x + Rust workflow:

Explanation of Key Improvements
Method Renaming

Renamed op() to instantiate_and_configure_scene() for clarity. This better communicates the method’s purpose: instantiating the “plays” scene and configuring a Label. Defensive Programming

Added checks (if let Some(...) = ...) to handle cases where: The user forgets to assign the plays property in the Godot Editor. Scene instantiation fails (rare, but can occur if the scene is corrupted). The Label node at the specified path isn’t found in the scene hierarchy. Uses godot_error!, godot_warn!, or godot_print! macros to log issues to the Godot console instead of panicking the entire game. Consistent Naming & Comments

The label_path string clarifies where the Label is expected. Comments explain how to switch between relative paths (child path within the same subtree) vs. absolute paths in the overall scene tree. Type-Safe Access

get_node_as::<Label> ensures the retrieved node is actually a Label. If the cast fails, we handle it gracefully. The new or_else block logs a warning if the node doesn’t exist. Maintainable & Extensible

The code is now easier to adapt if you need to do more with instance or other child nodes. The property plays remains exported (#[export]), so you can still set it from the Godot Editor. Minimal Global State

Everything is kept within the Tilesm struct, so there’s no hidden reliance on global singletons (except for normal Godot usage like Engine or SceneTree if desired). Additional Suggestions
Path Management: Depending on your scene structure, you may prefer relative vs. absolute paths: Relative Path: If the PLAYERS/Label node is a child of the newly instantiated scene’s root, use "PLAYERS/Label" directly. Absolute Path: If it’s truly under some top-level parent, use a path like "/root/.../Label", but confirm it matches the actual scene tree structure. Further Customization:
Store the instantiated node in a member field if you need to reference it later. Expose additional properties or signals to let other scripts know when the scene has finished loading or the label text has changed. With these changes, your Rust-based Godot code will be more robust, clear, and aligned with good practices for Godot 4 + Rust.